### PR TITLE
Logg maskert fødselsnummer kun til sikre logger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
-version = "1.0.0"
+version = "1.0.1"
 
 plugins {
     kotlin("jvm")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -9,7 +9,6 @@ import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.cache.getIfCacheNotNull
-import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 /**
@@ -24,7 +23,6 @@ class Altinn3M2MClient(
     private val getToken: () -> String,
     cacheConfig: CacheConfig? = null,
 ) {
-    private val logger = this.logger()
     private val sikkerLogger = sikkerLogger()
 
     private val urlString = "$baseUrl/m2m/altinn-tilganger"
@@ -37,10 +35,7 @@ class Altinn3M2MClient(
 
     suspend fun hentHierarkiMedTilganger(fnr: String): AltinnTilgangRespons =
         cache.getIfCacheNotNull(fnr) {
-            "Henter Altinntilganger fra Fager sitt m2m-endepunkt for ${fnr.take(5)}XXXXX".also {
-                logger.info(it)
-                sikkerLogger.info(it)
-            }
+            sikkerLogger.info("Henter Altinntilganger fra Fager sitt m2m-endepunkt for ${fnr.take(6)}XXXX")
 
             val request = TilgangM2MRequest(fnr, tilgangFilter)
 
@@ -51,10 +46,7 @@ class Altinn3M2MClient(
                     setBody(request)
                 }.body<AltinnTilgangRespons>()
                 .also { respons ->
-                    "Hentet Altinntilganger for ${fnr.take(5)}XXXXX med ${respons.hierarki.size} hovedenheter.".also {
-                        logger.info(it)
-                        sikkerLogger.info(it)
-                    }
+                    sikkerLogger.info("Hentet Altinntilganger for ${fnr.take(6)}XXXX med ${respons.hierarki.size} hovedenheter.")
                 }
         }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -9,7 +9,6 @@ import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.cache.getIfCacheNotNull
-import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 /**
@@ -22,7 +21,6 @@ class Altinn3OBOClient(
     private val serviceCode: String,
     cacheConfig: CacheConfig? = null,
 ) {
-    private val logger = this.logger()
     private val sikkerLogger = sikkerLogger()
 
     private val urlString = "$baseUrl/altinn-tilganger"
@@ -35,10 +33,10 @@ class Altinn3OBOClient(
     private val tilgangRequest =
         TilgangOBORequest(
             filter =
-            Filter(
-                altinn2Tilganger = setOf("$serviceCode:1"),
-                altinn3Tilganger = emptySet(),
-            ),
+                Filter(
+                    altinn2Tilganger = setOf("$serviceCode:1"),
+                    altinn3Tilganger = emptySet(),
+                ),
         )
 
     suspend fun hentHierarkiMedTilganger(
@@ -46,10 +44,7 @@ class Altinn3OBOClient(
         getToken: () -> String,
     ): AltinnTilgangRespons =
         cache.getIfCacheNotNull(fnr) {
-            "Henter Altinntilganger fra Fager sitt obo-endepunkt for ${fnr.take(5)}XXXXX".also {
-                logger.info(it)
-                sikkerLogger.info(it)
-            }
+            sikkerLogger.info("Henter Altinntilganger fra Fager sitt obo-endepunkt for ${fnr.take(6)}XXXX")
 
             httpClient
                 .post(urlString) {
@@ -58,10 +53,7 @@ class Altinn3OBOClient(
                     setBody(tilgangRequest)
                 }.body<AltinnTilgangRespons>()
                 .also { respons ->
-                    "Hentet Altinntilganger for ${fnr.take(5)}XXXXX med ${respons.hierarki.size} hovedenheter.".also {
-                        logger.info(it)
-                        sikkerLogger.info(it)
-                    }
+                    sikkerLogger.info("Hentet Altinntilganger for ${fnr.take(6)}XXXX med ${respons.hierarki.size} hovedenheter.")
                 }
         }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -33,10 +33,10 @@ class Altinn3OBOClient(
     private val tilgangRequest =
         TilgangOBORequest(
             filter =
-                Filter(
-                    altinn2Tilganger = setOf("$serviceCode:1"),
-                    altinn3Tilganger = emptySet(),
-                ),
+            Filter(
+                altinn2Tilganger = setOf("$serviceCode:1"),
+                altinn3Tilganger = emptySet(),
+            ),
         )
 
     suspend fun hentHierarkiMedTilganger(


### PR DESCRIPTION
Jeg ble litt forvirret av at denne loggen i den gamle Altinn-klienten ble logget til vanlige logger (`logger.debug()`) og at den allerede var maskert (som fikk meg til å tenke at den var grei for vanlige logger). 

Vi har kommet frem til at det ryddigste er å kun ha dette i `sikkerLogger`.