### PR TITLE
Legg til støtte for altinn3 ressurser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Altinn klient
+
+Dette er en klient for å koble seg på fager sitt [altinn-tilganger api](https://github.com/navikt/arbeidsgiver-altinn-tilganger).
+Dette bruker vi for å hente ut hvilke organisasjoner en bruker har tilgang til i altinn, og hvilke roller de har i disse organisasjonene. 
+Dette brukes igjen for tilgangskontroll i diverse backend applikasjoner feks [fritakagp](https://github.com/navikt/fritakagp) og [simba](https://github.com/navikt/helsearbeidsgiver-inntektsmelding).
+
+## bruk av klienten:
+
+### OBO klient:
+```kotlin
+        val altinnKlient = Altinn3OBOClient(
+            baseUrl = "http://arbeidsgiver-altinn-tilganger.fager",
+            serviceCode = "4936",
+            ressurs = Altinn3Ressurs.FRITAKAGP,
+            cacheConfig = LocalCache.Config(60.minutes, 250)
+        )
+        val altinnTilganger = altinnKlient.hentAltinnTilganger("12345678910", {"Tokenx token"})
+```
+
+### M2M klient:
+```kotlin
+        val altinnKlient = Altinn3M2MClient(
+            baseUrl = "http://arbeidsgiver-altinn-tilganger.fager",
+            serviceCode = "4936",
+            ressurs = Altinn3Ressurs.FRITAKAGP,
+            cacheConfig = LocalCache.Config(60.minutes, 250),
+            getToken = {"Entra token"}
+        )
+        val altinnTilganger = altinnKlient.hentAltinnTilganger("12345678910")
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=1.2.2
+version=1.3.0
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -58,8 +58,6 @@ class Altinn3M2MClient(
             altinn2Tilganger + altinn3Tilganger
         }
 
-    suspend fun hentAltinn3Tilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).organisasjonerMedAltinn3Tilgang()
-
     fun AltinnTilgangRespons.organisasjonerMedAltinn2Tilgang(): Set<String> = tilgangTilOrgNr["$serviceCode:1"].orEmpty()
 
     fun AltinnTilgangRespons.organisasjonerMedAltinn3Tilgang(): Set<String> = tilgangTilOrgNr[ressurs.value].orEmpty()
@@ -68,11 +66,6 @@ class Altinn3M2MClient(
         fnr: String,
         orgnr: String,
     ): Boolean = orgnr in hentTilganger(fnr)
-
-    suspend fun harTilgangTilOrganisasjonAltinn3(
-        fnr: String,
-        orgnr: String,
-    ): Boolean = orgnr in hentAltinn3Tilganger(fnr)
 }
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -19,6 +19,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 class Altinn3M2MClient(
     baseUrl: String,
     private val serviceCode: String,
+    val ressurs: Altinn3Ressurs,
     cacheConfig: LocalCache.Config,
     private val getToken: () -> String,
 ) {
@@ -27,7 +28,7 @@ class Altinn3M2MClient(
     private val urlString = "$baseUrl/m2m/altinn-tilganger"
     private val httpClient = createHttpClient()
     private val cache = LocalCache<AltinnTilgangRespons>(cacheConfig)
-    private val tilgangFilter = Filter(altinn2Tilganger = setOf("$serviceCode:1"), altinn3Tilganger = emptySet())
+    private val tilgangFilter = Filter(altinn2Tilganger = setOf("$serviceCode:1"), altinn3Tilganger = setOf(ressurs.value))
 
     suspend fun hentHierarkiMedTilganger(fnr: String): AltinnTilgangRespons =
         cache.getOrPut(fnr) {
@@ -48,10 +49,17 @@ class Altinn3M2MClient(
 
     suspend fun hentTilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).tilgangTilOrgNr["$serviceCode:1"].orEmpty()
 
+    suspend fun hentAltinn3Tilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).tilgangTilOrgNr[ressurs.value].orEmpty()
+
     suspend fun harTilgangTilOrganisasjon(
         fnr: String,
         orgnr: String,
     ): Boolean = orgnr in hentTilganger(fnr)
+
+    suspend fun harTilgangTilOrganisasjonAltinn3(
+        fnr: String,
+        orgnr: String,
+    ): Boolean = orgnr in hentAltinn3Tilganger(fnr)
 }
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -47,9 +47,22 @@ class Altinn3M2MClient(
                 }
         }
 
-    suspend fun hentTilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).tilgangTilOrgNr["$serviceCode:1"].orEmpty()
+    suspend fun hentTilganger(fnr: String): Set<String> =
+        hentHierarkiMedTilganger(fnr).let {
+            val altinn2Tilganger =
+                it.organisasjonerMedAltinn2Tilgang()
+            val altinn3Tilganger = it.organisasjonerMedAltinn3Tilgang()
+            sikkerLogger().info(
+                "Hentet tilganger for ${fnr.take(6)}XXXX: antall tilganger Altinn2: ${altinn2Tilganger.size}, Altinn3: ${altinn3Tilganger.size}",
+            )
+            altinn2Tilganger + altinn3Tilganger
+        }
 
-    suspend fun hentAltinn3Tilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).tilgangTilOrgNr[ressurs.value].orEmpty()
+    suspend fun hentAltinn3Tilganger(fnr: String): Set<String> = hentHierarkiMedTilganger(fnr).organisasjonerMedAltinn3Tilgang()
+
+    fun AltinnTilgangRespons.organisasjonerMedAltinn2Tilgang(): Set<String> = tilgangTilOrgNr["$serviceCode:1"].orEmpty()
+
+    fun AltinnTilgangRespons.organisasjonerMedAltinn3Tilgang(): Set<String> = tilgangTilOrgNr[ressurs.value].orEmpty()
 
     suspend fun harTilgangTilOrganisasjon(
         fnr: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -52,8 +52,9 @@ class Altinn3M2MClient(
             val altinn2Tilganger =
                 it.organisasjonerMedAltinn2Tilgang()
             val altinn3Tilganger = it.organisasjonerMedAltinn3Tilgang()
+            val diffTilganger = altinn2Tilganger.minus(altinn3Tilganger)
             sikkerLogger().info(
-                "Hentet tilganger for ${fnr.take(6)}XXXX: antall tilganger Altinn2: ${altinn2Tilganger.size}, Altinn3: ${altinn3Tilganger.size}",
+                "Hentet altinn tilganger for ${fnr.take(6)}XXXXX: diff antall: ${diffTilganger.size}, diff: $diffTilganger",
             )
             altinn2Tilganger + altinn3Tilganger
         }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -62,8 +62,9 @@ class Altinn3OBOClient(
             val altinn2Tilganger =
                 it.organisasjonerMedAltinn2Tilgang()
             val altinn3Tilganger = it.organisasjonerMedAltinn3Tilgang()
+            val diffTilganger = altinn2Tilganger.minus(altinn3Tilganger)
             sikkerLogger().info(
-                "Hentet tilganger for ${fnr.take(6)}XXXX: antall tilganger Altinn2: ${altinn2Tilganger.size}, Altinn3: ${altinn3Tilganger.size}",
+                "Hentet altinn tilganger for ${fnr.take(6)}XXXXX: diff antall: ${diffTilganger.size}, diff: $diffTilganger",
             )
             altinn2Tilganger + altinn3Tilganger
         }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -32,7 +32,7 @@ class Altinn3OBOClient(
             filter =
                 Filter(
                     altinn2Tilganger = setOf("$serviceCode:1"),
-                    altinn3Tilganger = emptySet(),
+                    altinn3Tilganger = setOf(ressurs.value),
                 ),
         )
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 class Altinn3OBOClient(
     baseUrl: String,
     private val serviceCode: String,
+    val ressurs: Altinn3Ressurs,
     cacheConfig: LocalCache.Config,
 ) {
     private val sikkerLogger = sikkerLogger()
@@ -56,7 +57,20 @@ class Altinn3OBOClient(
     suspend fun hentTilganger(
         fnr: String,
         getToken: () -> String,
-    ): Set<String> = hentHierarkiMedTilganger(fnr, getToken).tilgangTilOrgNr["$serviceCode:1"].orEmpty()
+    ): Set<String> =
+        hentHierarkiMedTilganger(fnr, getToken).let {
+            val altinn2Tilganger =
+                it.organisasjonerMedAltinn2Tilgang()
+            val altinn3Tilganger = it.organisasjonerMedAltinn3Tilgang()
+            sikkerLogger().info(
+                "Hentet tilganger for ${fnr.take(6)}XXXX: antall tilganger Altinn2: ${altinn2Tilganger.size}, Altinn3: ${altinn3Tilganger.size}",
+            )
+            altinn2Tilganger + altinn3Tilganger
+        }
+
+    fun AltinnTilgangRespons.organisasjonerMedAltinn2Tilgang(): Set<String> = tilgangTilOrgNr["$serviceCode:1"].orEmpty()
+
+    fun AltinnTilgangRespons.organisasjonerMedAltinn3Tilgang(): Set<String> = tilgangTilOrgNr[ressurs.value].orEmpty()
 
     suspend fun harTilgangTilOrganisasjon(
         fnr: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3Ressurs.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3Ressurs.kt
@@ -1,0 +1,8 @@
+package no.nav.helsearbeidsgiver.altinn
+
+enum class Altinn3Ressurs(
+    val value: String,
+) {
+    INNTEKTSMELDING("nav_sykepenger_inntektsmelding"),
+    FRITAKAGP("nav_sykepenger_fritak-arbeidsgiverperiode"),
+}

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
@@ -60,30 +60,6 @@ class Altinn3ClientTest :
             }
         }
 
-        context("fnr har kun rettigheter tilknyttet organisasjoner som Altinn returnerer for Altinn3-ressurs") {
-            withData(
-                mapOf<String, suspend (Pair<HttpStatusCode, String>, String) -> Boolean>(
-                    "Altinn M2M" to { responses, orgnr -> mockAltinn3M2MClient(responses).harTilgangTilOrganisasjonAltinn3(FNR, orgnr) },
-                ),
-            ) { harTilgangTilOrganisasjon ->
-                listOf(
-                    "810007842" to true,
-                    "810007702" to true, // Er hovedenhet
-                    "123456789" to false, // Er ikke i listen fra responsen
-                ).forEach { (orgnr, expected) ->
-                    val harTilgang =
-                        harTilgangTilOrganisasjon(
-                            HttpStatusCode.OK to validAltinnResponse,
-                            orgnr,
-                        )
-
-                    withClue("$orgnr should yield $expected") {
-                        harTilgang shouldBe expected
-                    }
-                }
-            }
-        }
-
         context("gyldig svar fra Altinn gir hierarki med liste av tilganger") {
             withData(
                 mapOf<String, suspend (Pair<HttpStatusCode, String>) -> AltinnTilgangRespons>(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
@@ -31,11 +31,11 @@ class Altinn3ClientTest :
             ) { hentTilganger ->
                 val tilganger = hentTilganger(HttpStatusCode.OK to validAltinnResponse)
 
-                tilganger.size shouldBeExactly 3
+                tilganger.size shouldBeExactly 7
             }
         }
 
-        context("fnr har kun rettigheter tilknyttet organisasjoner som Altinn returnerer og som er underenheter") {
+        context("fnr har kun rettigheter tilknyttet organisasjoner som Altinn returnerer") {
             withData(
                 mapOf<String, suspend (Pair<HttpStatusCode, String>, String) -> Boolean>(
                     "Altinn M2M" to { responses, orgnr -> mockAltinn3M2MClient(responses).harTilgangTilOrganisasjon(FNR, orgnr) },
@@ -44,7 +44,31 @@ class Altinn3ClientTest :
             ) { harTilgangTilOrganisasjon ->
                 listOf(
                     "810007842" to true,
-                    "810007702" to false, // Er hovedenhet
+                    "810007702" to true, // Er hovedenhet
+                    "123456789" to false, // Er ikke i listen fra responsen
+                ).forEach { (orgnr, expected) ->
+                    val harTilgang =
+                        harTilgangTilOrganisasjon(
+                            HttpStatusCode.OK to validAltinnResponse,
+                            orgnr,
+                        )
+
+                    withClue("$orgnr should yield $expected") {
+                        harTilgang shouldBe expected
+                    }
+                }
+            }
+        }
+
+        context("fnr har kun rettigheter tilknyttet organisasjoner som Altinn returnerer for Altinn3-ressurs") {
+            withData(
+                mapOf<String, suspend (Pair<HttpStatusCode, String>, String) -> Boolean>(
+                    "Altinn M2M" to { responses, orgnr -> mockAltinn3M2MClient(responses).harTilgangTilOrganisasjonAltinn3(FNR, orgnr) },
+                ),
+            ) { harTilgangTilOrganisasjon ->
+                listOf(
+                    "810007842" to true,
+                    "810007702" to true, // Er hovedenhet
                     "123456789" to false, // Er ikke i listen fra responsen
                 ).forEach { (orgnr, expected) ->
                     val harTilgang =
@@ -75,8 +99,8 @@ class Altinn3ClientTest :
                 hovedEnhet?.underenheter?.shouldHaveSize(3)
                 hovedEnhet?.underenheter?.map {
                     it.navn
-                } shouldContainExactly setOf("ANSTENDIG PIGGSVIN BARNEHAGE", "ANSTENDIG PIGGSVIN SYKEHJEM", "ANSTENDIG PIGGSVIN BRANNVESEN")
-                hovedEnhet?.underenheter?.map { it.orgnr } shouldContainExactly setOf("810007842", "810007982", "810008032")
+                } shouldContainExactly setOf("ANSTENDIG PIGGSVIN BRANNVESEN", "ANSTENDIG PIGGSVIN SYKEHJEM", "ANSTENDIG PIGGSVIN BARNEHAGE")
+                hovedEnhet?.underenheter?.map { it.orgnr } shouldContainExactly setOf("810008032", "810007982", "810007842")
             }
         }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
@@ -15,7 +15,7 @@ import kotlin.time.Duration
 
 fun mockAltinn3M2MClient(vararg responses: Pair<HttpStatusCode, String>): Altinn3M2MClient =
     mockClient(*responses) {
-        Altinn3M2MClient("url", "4936", LocalCache.Config(Duration.ZERO, 1)) { "" }
+        Altinn3M2MClient("url", "4936", Altinn3Ressurs.INNTEKTSMELDING, LocalCache.Config(Duration.ZERO, 1)) { "" }
     }
 
 fun mockAltinn3OBOClient(vararg responses: Pair<HttpStatusCode, String>): Altinn3OBOClient =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
@@ -20,7 +20,7 @@ fun mockAltinn3M2MClient(vararg responses: Pair<HttpStatusCode, String>): Altinn
 
 fun mockAltinn3OBOClient(vararg responses: Pair<HttpStatusCode, String>): Altinn3OBOClient =
     mockClient(*responses) {
-        Altinn3OBOClient("url", "4936", LocalCache.Config(Duration.ZERO, 1))
+        Altinn3OBOClient("url", "4936", Altinn3Ressurs.INNTEKTSMELDING, LocalCache.Config(Duration.ZERO, 1))
     }
 
 private fun <T : Any> mockClient(

--- a/src/test/resources/rettighetene-til-tanja-minge.json
+++ b/src/test/resources/rettighetene-til-tanja-minge.json
@@ -2,243 +2,745 @@
   "isError": false,
   "hierarki": [
     {
-      "orgnr": "810007672",
+      "orgnr": "911206722",
       "altinn3Tilganger": [
-        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
+        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+        "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+        "nav_sykepenger_inntektsmelding",
+        "nav_sykepenger_fritak-arbeidsgiverperiode",
+        "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+        "nav_arbeidsforhold_aa-registeret-brukerstotte",
+        "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+        "nav_syfo_dialogmote",
+        "nav_syfo_oppfolgingsplan",
+        "nav_syfo_oppgi-narmesteleder",
+        "test-fager",
+        "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+        "nav_tiltak_tiltaksrefusjon",
+        "nav_foreldrepenger_inntektsmelding",
+        "nav_rekruttering_stillingsannonser",
+        "nav_rekruttering_kandidater",
+        "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+        "nav_test_melding",
+        "nav_sosialtjenester_digisos-avtale"
       ],
       "altinn2Tilganger": [
         "5810:1",
-        "5934:1",
-        "3403:1",
         "2896:87",
-        "5516:2",
-        "5332:1",
-        "5384:1",
+        "5441:1",
+        "5441:2",
+        "5719:1",
         "5078:1",
+        "3403:1",
+        "5867:1",
         "4826:1",
         "4936:1",
-        "5902:1",
         "5278:1",
-        "5516:3",
-        "5441:1",
+        "5332:1",
+        "5384:1",
         "5516:1",
+        "5516:2",
+        "5516:3",
+        "5516:4",
         "5516:5",
-        "5516:4"
+        "5516:6",
+        "5902:1",
+        "4596:1"
       ],
       "underenheter": [],
-      "navn": "ANSTENDIG BJØRN KOMMUNE",
-      "organisasjonsform": "KOMM"
+      "navn": "SKOPPUM OG SANDØY",
+      "organisasjonsform": "BEDR",
+      "erSlettet": false
     },
     {
       "orgnr": "810007702",
-      "altinn3Tilganger": [],
+      "altinn3Tilganger": [
+        "test-fager",
+        "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+        "nav_tiltak_tiltaksrefusjon",
+        "nav_foreldrepenger_inntektsmelding",
+        "nav_sykepenger_inntektsmelding",
+        "nav_sykepenger_fritak-arbeidsgiverperiode",
+        "nav_rekruttering_stillingsannonser",
+        "nav_rekruttering_kandidater",
+        "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+      ],
       "altinn2Tilganger": [
-        "5934:1",
-        "3403:1",
-        "2896:87",
-        "5332:1",
-        "5384:1",
         "5078:1",
+        "3403:1",
         "4826:1",
         "4936:1",
+        "5332:1",
+        "5384:1",
         "5902:1"
       ],
       "underenheter": [
         {
-          "orgnr": "810007842",
-          "altinn3Tilganger": [],
-          "altinn2Tilganger": [
-            "5934:1",
-            "3403:1",
-            "2896:87",
-            "5332:1",
-            "5384:1",
-            "5078:1",
-            "4826:1",
-            "4936:1",
-            "5902:1"
-          ],
-          "underenheter": [],
-          "navn": "ANSTENDIG PIGGSVIN BARNEHAGE",
-          "organisasjonsform": "BEDR"
-        },
-        {
-          "orgnr": "810007982",
-          "altinn3Tilganger": [],
-          "altinn2Tilganger": [
-            "5934:1",
-            "3403:1",
-            "2896:87",
-            "5332:1",
-            "5384:1",
-            "5078:1",
-            "4826:1",
-            "4936:1",
-            "5902:1"
-          ],
-          "underenheter": [],
-          "navn": "ANSTENDIG PIGGSVIN SYKEHJEM",
-          "organisasjonsform": "BEDR"
-        },
-        {
           "orgnr": "810008032",
-          "altinn3Tilganger": [],
+          "altinn3Tilganger": [
+            "test-fager",
+            "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+            "nav_tiltak_tiltaksrefusjon",
+            "nav_foreldrepenger_inntektsmelding",
+            "nav_sykepenger_inntektsmelding",
+            "nav_sykepenger_fritak-arbeidsgiverperiode",
+            "nav_rekruttering_stillingsannonser",
+            "nav_rekruttering_kandidater",
+            "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+          ],
           "altinn2Tilganger": [
-            "5934:1",
-            "3403:1",
-            "2896:87",
-            "5332:1",
-            "5384:1",
             "5078:1",
+            "3403:1",
             "4826:1",
             "4936:1",
+            "5332:1",
+            "5384:1",
             "5902:1"
           ],
           "underenheter": [],
           "navn": "ANSTENDIG PIGGSVIN BRANNVESEN",
-          "organisasjonsform": "BEDR"
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
+        },
+        {
+          "orgnr": "810007982",
+          "altinn3Tilganger": [
+            "test-fager",
+            "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+            "nav_tiltak_tiltaksrefusjon",
+            "nav_foreldrepenger_inntektsmelding",
+            "nav_sykepenger_inntektsmelding",
+            "nav_sykepenger_fritak-arbeidsgiverperiode",
+            "nav_rekruttering_stillingsannonser",
+            "nav_rekruttering_kandidater",
+            "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+          ],
+          "altinn2Tilganger": [
+            "5078:1",
+            "3403:1",
+            "4826:1",
+            "4936:1",
+            "5332:1",
+            "5384:1",
+            "5902:1"
+          ],
+          "underenheter": [],
+          "navn": "ANSTENDIG PIGGSVIN SYKEHJEM",
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
+        },
+        {
+          "orgnr": "810007842",
+          "altinn3Tilganger": [
+            "app_nav_a2-4596-1",
+            "nav-migratedcorrespondence-4503-2",
+            "test-fager",
+            "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+            "nav_tiltak_tiltaksrefusjon",
+            "nav_foreldrepenger_inntektsmelding",
+            "nav_sykepenger_inntektsmelding",
+            "nav_sykepenger_fritak-arbeidsgiverperiode",
+            "nav_rekruttering_stillingsannonser",
+            "nav_rekruttering_kandidater",
+            "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+          ],
+          "altinn2Tilganger": [
+            "5078:1",
+            "3403:1",
+            "4826:1",
+            "4936:1",
+            "5332:1",
+            "5384:1",
+            "5902:1",
+            "4596:1"
+          ],
+          "underenheter": [],
+          "navn": "ANSTENDIG PIGGSVIN BARNEHAGE",
+          "organisasjonsform": "BEDR",
+          "erSlettet": false
         }
       ],
       "navn": "ANSTENDIG PIGGSVIN BYDEL",
-      "organisasjonsform": "ORGL"
+      "organisasjonsform": "ORGL",
+      "erSlettet": false
+    },
+    {
+      "orgnr": "810007672",
+      "altinn3Tilganger": [
+        "test-fager",
+        "nav_test_melding",
+        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+        "nav_sosialtjenester_digisos-avtale",
+        "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+        "nav_sykepenger_inntektsmelding",
+        "nav_sykepenger_fritak-arbeidsgiverperiode",
+        "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+        "nav_arbeidsforhold_aa-registeret-brukerstotte",
+        "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+        "nav_syfo_dialogmote",
+        "nav_syfo_oppfolgingsplan",
+        "nav_syfo_oppgi-narmesteleder",
+        "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+        "nav_tiltak_tiltaksrefusjon",
+        "nav_foreldrepenger_inntektsmelding",
+        "nav_rekruttering_stillingsannonser",
+        "nav_rekruttering_kandidater",
+        "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+      ],
+      "altinn2Tilganger": [
+        "5810:1",
+        "5867:1",
+        "2896:87",
+        "5441:1",
+        "5441:2",
+        "5719:1",
+        "5078:1",
+        "3403:1",
+        "4826:1",
+        "4936:1",
+        "5278:1",
+        "5332:1",
+        "5384:1",
+        "5516:1",
+        "5516:2",
+        "5516:3",
+        "5516:4",
+        "5516:5",
+        "5516:6",
+        "5902:1",
+        "4596:1"
+      ],
+      "underenheter": [],
+      "navn": "ANSTENDIG BJØRN KOMMUNE",
+      "organisasjonsform": "KOMM",
+      "erSlettet": false
     },
     {
       "orgnr": "911212218",
       "altinn3Tilganger": [
-        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
+        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+        "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+        "nav_sykepenger_inntektsmelding",
+        "nav_sykepenger_fritak-arbeidsgiverperiode",
+        "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+        "nav_arbeidsforhold_aa-registeret-brukerstotte",
+        "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+        "nav_syfo_dialogmote",
+        "nav_syfo_oppfolgingsplan",
+        "nav_syfo_oppgi-narmesteleder",
+        "test-fager",
+        "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+        "nav_tiltak_tiltaksrefusjon",
+        "nav_foreldrepenger_inntektsmelding",
+        "nav_rekruttering_stillingsannonser",
+        "nav_rekruttering_kandidater",
+        "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+        "nav_test_melding",
+        "nav_sosialtjenester_digisos-avtale"
       ],
       "altinn2Tilganger": [
         "5810:1",
-        "5934:1",
-        "3403:1",
         "2896:87",
-        "5516:2",
-        "5332:1",
-        "5384:1",
+        "5441:1",
+        "5441:2",
+        "5719:1",
         "5078:1",
+        "3403:1",
+        "5867:1",
         "4826:1",
         "4936:1",
-        "5902:1",
         "5278:1",
-        "5516:3",
-        "5441:1",
+        "5332:1",
+        "5384:1",
         "5516:1",
+        "5516:2",
+        "5516:3",
+        "5516:4",
         "5516:5",
-        "5516:4"
+        "5516:6",
+        "5902:1",
+        "4596:1"
       ],
       "underenheter": [],
       "navn": "SKJERSTAD OG KJØRSVIKBUGEN",
-      "organisasjonsform": "AS"
-    },
-    {
-      "orgnr": "911206722",
-      "altinn3Tilganger": [
-        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger"
-      ],
-      "altinn2Tilganger": [
-        "5810:1",
-        "5934:1",
-        "3403:1",
-        "2896:87",
-        "5516:2",
-        "5332:1",
-        "5384:1",
-        "5078:1",
-        "4826:1",
-        "4936:1",
-        "5902:1",
-        "5278:1",
-        "5516:3",
-        "5441:1",
-        "5516:1",
-        "5516:5",
-        "5516:4"
-      ],
-      "underenheter": [],
-      "navn": "SKOPPUM OG SANDØY",
-      "organisasjonsform": "BEDR"
+      "organisasjonsform": "AS",
+      "erSlettet": false
     }
   ],
   "orgNrTilTilganger": {
-    "810007842": [
-      "5934:1",
-      "3403:1",
+    "810007672": [
+      "5810:1",
+      "5867:1",
       "2896:87",
-      "5332:1",
-      "5384:1",
+      "5441:1",
+      "5441:2",
+      "5719:1",
       "5078:1",
+      "3403:1",
       "4826:1",
       "4936:1",
-      "5902:1"
+      "5278:1",
+      "5332:1",
+      "5384:1",
+      "5516:1",
+      "5516:2",
+      "5516:3",
+      "5516:4",
+      "5516:5",
+      "5516:6",
+      "5902:1",
+      "4596:1",
+      "test-fager",
+      "nav_test_melding",
+      "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+      "nav_sosialtjenester_digisos-avtale",
+      "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+      "nav_arbeidsforhold_aa-registeret-brukerstotte",
+      "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+      "nav_syfo_dialogmote",
+      "nav_syfo_oppfolgingsplan",
+      "nav_syfo_oppgi-narmesteleder",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+    ],
+    "810007702": [
+      "5078:1",
+      "3403:1",
+      "4826:1",
+      "4936:1",
+      "5332:1",
+      "5384:1",
+      "5902:1",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+    ],
+    "810007842": [
+      "5078:1",
+      "3403:1",
+      "4826:1",
+      "4936:1",
+      "5332:1",
+      "5384:1",
+      "5902:1",
+      "4596:1",
+      "app_nav_a2-4596-1",
+      "nav-migratedcorrespondence-4503-2",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
     ],
     "810007982": [
-      "5934:1",
-      "3403:1",
-      "2896:87",
-      "5332:1",
-      "5384:1",
       "5078:1",
+      "3403:1",
       "4826:1",
       "4936:1",
-      "5902:1"
+      "5332:1",
+      "5384:1",
+      "5902:1",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
     ],
     "810008032": [
-      "5934:1",
-      "3403:1",
-      "2896:87",
-      "5332:1",
-      "5384:1",
       "5078:1",
+      "3403:1",
       "4826:1",
       "4936:1",
-      "5902:1"
+      "5332:1",
+      "5384:1",
+      "5902:1",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+    ],
+    "911206722": [
+      "5810:1",
+      "2896:87",
+      "5441:1",
+      "5441:2",
+      "5719:1",
+      "5078:1",
+      "3403:1",
+      "5867:1",
+      "4826:1",
+      "4936:1",
+      "5278:1",
+      "5332:1",
+      "5384:1",
+      "5516:1",
+      "5516:2",
+      "5516:3",
+      "5516:4",
+      "5516:5",
+      "5516:6",
+      "5902:1",
+      "4596:1",
+      "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+      "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+      "nav_arbeidsforhold_aa-registeret-brukerstotte",
+      "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+      "nav_syfo_dialogmote",
+      "nav_syfo_oppfolgingsplan",
+      "nav_syfo_oppgi-narmesteleder",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+      "nav_test_melding",
+      "nav_sosialtjenester_digisos-avtale"
+    ],
+    "911212218": [
+      "5810:1",
+      "2896:87",
+      "5441:1",
+      "5441:2",
+      "5719:1",
+      "5078:1",
+      "3403:1",
+      "5867:1",
+      "4826:1",
+      "4936:1",
+      "5278:1",
+      "5332:1",
+      "5384:1",
+      "5516:1",
+      "5516:2",
+      "5516:3",
+      "5516:4",
+      "5516:5",
+      "5516:6",
+      "5902:1",
+      "4596:1",
+      "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+      "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver",
+      "nav_sykepenger_inntektsmelding",
+      "nav_sykepenger_fritak-arbeidsgiverperiode",
+      "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver",
+      "nav_arbeidsforhold_aa-registeret-brukerstotte",
+      "nav_arbeidsforhold_aa-registeret-sok-tilgang",
+      "nav_syfo_dialogmote",
+      "nav_syfo_oppfolgingsplan",
+      "nav_syfo_oppgi-narmesteleder",
+      "test-fager",
+      "nav_forebygge-og-redusere-sykefravar_ia-samarbeid",
+      "nav_tiltak_tiltaksrefusjon",
+      "nav_foreldrepenger_inntektsmelding",
+      "nav_rekruttering_stillingsannonser",
+      "nav_rekruttering_kandidater",
+      "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+      "nav_test_melding",
+      "nav_sosialtjenester_digisos-avtale"
     ]
   },
   "tilgangTilOrgNr": {
-    "5934:1": [
-      "810007842",
-      "810007982",
-      "810008032"
-    ],
-    "3403:1": [
-      "810007842",
-      "810007982",
-      "810008032"
+    "5810:1": [
+      "911206722",
+      "810007672",
+      "911212218"
     ],
     "2896:87": [
-      "810007842",
-      "810007982",
-      "810008032"
+      "911206722",
+      "810007672",
+      "911212218"
     ],
-    "5332:1": [
-      "810007842",
-      "810007982",
-      "810008032"
+    "5441:1": [
+      "911206722",
+      "810007672",
+      "911212218"
     ],
-    "5384:1": [
-      "810007842",
-      "810007982",
-      "810008032"
+    "5441:2": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5719:1": [
+      "911206722",
+      "810007672",
+      "911212218"
     ],
     "5078:1": [
-      "810007842",
+      "911206722",
+      "810007702",
+      "810008032",
       "810007982",
-      "810008032"
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "3403:1": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "5867:1": [
+      "911206722",
+      "810007672",
+      "911212218"
     ],
     "4826:1": [
-      "810007842",
+      "911206722",
+      "810007702",
+      "810008032",
       "810007982",
-      "810008032"
+      "810007842",
+      "810007672",
+      "911212218"
     ],
     "4936:1": [
-      "810007842",
+      "911206722",
+      "810007702",
+      "810008032",
       "810007982",
-      "810008032"
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "5278:1": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5332:1": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "5384:1": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "5516:1": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5516:2": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5516:3": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5516:4": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5516:5": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "5516:6": [
+      "911206722",
+      "810007672",
+      "911212218"
     ],
     "5902:1": [
-      "810007842",
+      "911206722",
+      "810007702",
+      "810008032",
       "810007982",
-      "810008032"
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "4596:1": [
+      "911206722",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_sykepenger_inntektsmelding": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_sykepenger_fritak-arbeidsgiverperiode": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_arbeidsforhold_aa-registeret-brukerstotte": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_arbeidsforhold_aa-registeret-sok-tilgang": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_syfo_dialogmote": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_syfo_oppfolgingsplan": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_syfo_oppgi-narmesteleder": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "test-fager": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_forebygge-og-redusere-sykefravar_ia-samarbeid": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_tiltak_tiltaksrefusjon": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_foreldrepenger_inntektsmelding": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_rekruttering_stillingsannonser": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_rekruttering_kandidater": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk": [
+      "911206722",
+      "810007702",
+      "810008032",
+      "810007982",
+      "810007842",
+      "810007672",
+      "911212218"
+    ],
+    "nav_test_melding": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "nav_sosialtjenester_digisos-avtale": [
+      "911206722",
+      "810007672",
+      "911212218"
+    ],
+    "app_nav_a2-4596-1": [
+      "810007842"
+    ],
+    "nav-migratedcorrespondence-4503-2": [
+      "810007842"
     ]
   }
 }


### PR DESCRIPTION
Legg til støtte for altinn3 ressurser i tilgangs oppslag.
Har fallback på tjenestekode. Så hvis en av de finnes gis tilgang.

Logger også antall tilganger av altinn2 og altinn3 til sikkerlogger for hver request. Så ser man om det er stort diff her i prod.


