### PR TITLE
Øk timeout-grenser

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3M2MClient.kt
@@ -13,7 +13,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 /**
  * Klient som benytter Team Fager sitt API for å hente hvilke tilganger en innlogget bruker har i hvilke virksomheter/bedrifter.
  *
- * API-dokumentasjon her: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui/index.html
+ * API-dokumentasjon her: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui
  */
 
 class Altinn3M2MClient(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3OBOClient.kt
@@ -13,7 +13,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 /**
  * Klient som benytter Team Fager sitt API for å hente hvilke tilganger en innlogget bruker har i hvilke virksomheter/bedrifter.
  *
- * API-dokumentasjon her: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui/index.html
+ * API-dokumentasjon her: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui
  */
 class Altinn3OBOClient(
     baseUrl: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/HttpUtils.kt
@@ -23,12 +23,12 @@ internal fun HttpClientConfig<*>.configure() {
             maxRetries = 3,
             retryOnTimeout = true,
         )
-        exponentialDelay()
+        constantDelay()
     }
 
     install(HttpTimeout) {
-        connectTimeoutMillis = 500
-        requestTimeoutMillis = 500
-        socketTimeoutMillis = 500
+        connectTimeoutMillis = 3000
+        requestTimeoutMillis = 3000
+        socketTimeoutMillis = 3000
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/Altinn3ClientTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.testCoroutineScheduler
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -13,7 +14,7 @@ import io.kotest.matchers.shouldNotBe
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ServerResponseException
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
 
 private val validAltinnResponse = "rettighetene-til-tanja-minge.json".readResource()
@@ -80,17 +81,20 @@ class Altinn3ClientTest :
             }
         }
 
-        listOf<Pair<String, suspend (Array<Pair<HttpStatusCode, String>>) -> Unit>>(
-            "Altinn M2M" to { mockAltinn3M2MClient(*it).hentHierarkiMedTilganger(FNR) },
-            "Altinn OBO" to { mockAltinn3OBOClient(*it).hentHierarkiMedTilganger(FNR) { "" } },
+        listOf<Pair<String, suspend (Array<Pair<HttpStatusCode, String>>, TestCoroutineScheduler?) -> Unit>>(
+            "Altinn M2M" to { responses, s -> mockAltinn3M2MClient(*responses, scheduler = s).hentHierarkiMedTilganger(FNR) },
+            "Altinn OBO" to { responses, s -> mockAltinn3OBOClient(*responses, scheduler = s).hentHierarkiMedTilganger(FNR) { "" } },
         ).forEach { (clientType, hentHierarkiMedTilganger) ->
             context(clientType) {
+                // Unngår venting på delay-funksjonen
+                coroutineTestScope = true
+
                 test("feiler ved 4xx-feil") {
                     val mockResponses = arrayOf(HttpStatusCode.NotFound to "")
 
                     val e =
                         shouldThrowExactly<ClientRequestException> {
-                            hentHierarkiMedTilganger(mockResponses)
+                            hentHierarkiMedTilganger(mockResponses, null)
                         }
 
                     e.response.status shouldBe HttpStatusCode.NotFound
@@ -105,10 +109,8 @@ class Altinn3ClientTest :
                             HttpStatusCode.OK to validAltinnResponse,
                         )
 
-                    runTest {
-                        shouldNotThrowAny {
-                            hentHierarkiMedTilganger(mockResponses)
-                        }
+                    shouldNotThrowAny {
+                        hentHierarkiMedTilganger(mockResponses, null)
                     }
                 }
 
@@ -121,14 +123,12 @@ class Altinn3ClientTest :
                             HttpStatusCode.InternalServerError to "",
                         )
 
-                    runTest {
-                        val e =
-                            shouldThrowExactly<ServerResponseException> {
-                                hentHierarkiMedTilganger(mockResponses)
-                            }
+                    val e =
+                        shouldThrowExactly<ServerResponseException> {
+                            hentHierarkiMedTilganger(mockResponses, null)
+                        }
 
-                        e.response.status shouldBe HttpStatusCode.InternalServerError
-                    }
+                    e.response.status shouldBe HttpStatusCode.InternalServerError
                 }
 
                 test("kall feiler og prøver på nytt ved timeout") {
@@ -140,10 +140,8 @@ class Altinn3ClientTest :
                             HttpStatusCode.OK to validAltinnResponse,
                         )
 
-                    runTest {
-                        shouldNotThrowAny {
-                            hentHierarkiMedTilganger(mockResponses)
-                        }
+                    shouldNotThrowAny {
+                        hentHierarkiMedTilganger(mockResponses, testCoroutineScheduler)
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/MockClient.kt
@@ -9,32 +9,46 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.mockk.every
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
-fun mockAltinn3M2MClient(vararg responses: Pair<HttpStatusCode, String>): Altinn3M2MClient =
-    mockClient(*responses) {
+fun mockAltinn3M2MClient(
+    vararg responses: Pair<HttpStatusCode, String>,
+    scheduler: TestCoroutineScheduler? = null,
+): Altinn3M2MClient =
+    mockClient(responses.toList(), scheduler) {
         Altinn3M2MClient("url", "4936", Altinn3Ressurs.INNTEKTSMELDING, LocalCache.Config(Duration.ZERO, 1)) { "" }
     }
 
-fun mockAltinn3OBOClient(vararg responses: Pair<HttpStatusCode, String>): Altinn3OBOClient =
-    mockClient(*responses) {
+fun mockAltinn3OBOClient(
+    vararg responses: Pair<HttpStatusCode, String>,
+    scheduler: TestCoroutineScheduler? = null,
+): Altinn3OBOClient =
+    mockClient(responses.toList(), scheduler) {
         Altinn3OBOClient("url", "4936", Altinn3Ressurs.INNTEKTSMELDING, LocalCache.Config(Duration.ZERO, 1))
     }
 
 private fun <T : Any> mockClient(
-    vararg responses: Pair<HttpStatusCode, String>,
+    responses: List<Pair<HttpStatusCode, String>>,
+    scheduler: TestCoroutineScheduler? = null,
     createClient: () -> T,
 ): T {
     val mockEngine =
         MockEngine.create {
+            if (scheduler != null) {
+                // Unngår venting på delay-funksjon kallt i request handler
+                dispatcher = StandardTestDispatcher(scheduler)
+            }
             reuseHandlers = false
             requestHandlers.addAll(
                 responses.map { (status, content) ->
                     {
                         if (content == "timeout") {
-                            delay(600)
+                            delay(3100.milliseconds)
                         }
                         respond(
                             content = content,


### PR DESCRIPTION
Vi har opplevd noen perioder med mange timeouts mot Altinn. Øker den nokså strenge timeout-grensen vi har i dag. Satte verdien basert på [responstidene](https://grafana.nav.cloud.nais.io/d/adznifal3auiof/team-fager-arbeidsgiver-altinn-tilganger?var-opplosning=5m&orgId=1&from=now-30d&to=now&timezone=browser&var-naisCluster=000000021&viewPanel=panel-38) Fager opplever mot Altinn.

Gjør noen endringer på testene for å unngå venting på kall til `delay(...)`.